### PR TITLE
Convert file paths to relative if given tb_base="."

### DIFF
--- a/wasabi/tests/test_traceback.py
+++ b/wasabi/tests/test_traceback.py
@@ -37,6 +37,18 @@ def test_traceback_printer_only_title(tb):
     print(msg)
 
 
+def test_traceback_dot_relative_path_tb_base(tb):
+    tbp = TracebackPrinter(tb_base=".")
+    msg = tbp("Hello world", tb=tb)
+    print(msg)
+
+
+def test_traceback_tb_base_none(tb):
+    tbp = TracebackPrinter()
+    msg = tbp("Hello world", tb=tb)
+    print(msg)
+
+
 def test_traceback_printer_no_tb():
     tbp = TracebackPrinter(tb_base="wasabi")
     msg = tbp("Hello world", "This is a test")

--- a/wasabi/traceback.py
+++ b/wasabi/traceback.py
@@ -1,6 +1,6 @@
 # coding: utf8
 from __future__ import unicode_literals, print_function
-
+import os
 from .util import color, supports_ansi, NO_UTF8
 
 
@@ -35,7 +35,11 @@ class TracebackPrinter(object):
         self.color_tb = color_tb
         self.color_highlight = color_highlight
         self.indent = " " * indent
-        self.tb_base = "/{}/".format(tb_base) if tb_base else None
+        if tb_base == ".":
+            tb_base = "{}{}".format(os.getcwd(), os.path.sep)
+        elif tb_base is not None:
+            tb_base = "/{}/".format(tb_base)
+        self.tb_base = tb_base
         self.tb_exclude = tuple(tb_exclude)
         self.supports_ansi = supports_ansi()
 


### PR DESCRIPTION
 - this is useful because it's often undesirable to have full path names in logs (e.g. when sharing them online)
 - stripping the paths and making them relative to the cwd still allows them to be clicked as links in modern IDEs
 - import the cwd and strip it from traceback names when tb_base is "."

