### PR TITLE
Better clickable traceback links

### DIFF
--- a/wasabi/traceback.py
+++ b/wasabi/traceback.py
@@ -76,7 +76,7 @@ class TracebackPrinter(object):
         )
 
     def _format_traceback(self, path, line, fn, text, i, count, highlight):
-        template = "{base_indent}{indent} {fn} [{line}] in {path}{text}"
+        template = "{base_indent}{indent} {fn} in {path}:{line}{text}"
         indent = (LINE_EDGE if i == count - 1 else LINE_FORK) + LINE_PATH * i
         if self.tb_base and self.tb_base in path:
             path = path.rsplit(self.tb_base, 1)[1]


### PR DESCRIPTION
By putting the line number at the end of the filename with a colon, IDEs like VSCode and the IntelliJ family of Jetbrains editors will click through to the line of the file!

![traceback-link-line-number](https://user-images.githubusercontent.com/101493/71527230-56357600-288f-11ea-81df-2068bc286640.gif)
