### PR TITLE
Add option to print timestamp

### DIFF
--- a/wasabi/printer.py
+++ b/wasabi/printer.py
@@ -132,7 +132,8 @@ class Printer(object):
         if text:
             title = "{}\n{}".format(title, wrap(text, indent=0))
         if self.timestamp:
-            title = "{}\t{}".format(datetime.datetime.now(), title)
+            now = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+            title = "{}\t{}".format(now, title)
         if exits is not None or spaced:
             title = "\n{}\n".format(title)
         if not self.no_print and not no_print:

--- a/wasabi/printer.py
+++ b/wasabi/printer.py
@@ -1,6 +1,7 @@
 # coding: utf8
 from __future__ import unicode_literals, print_function
 
+import datetime
 from collections import Counter
 from contextlib import contextmanager
 from multiprocessing import Process
@@ -28,6 +29,7 @@ class Printer(object):
         hide_animation=False,
         ignore_warnings=False,
         env_prefix="WASABI",
+        timestamp=False,
     ):
         """Initialize the command-line printer.
 
@@ -42,6 +44,7 @@ class Printer(object):
         ignore_warnings (bool): Do not output messages of type MESSAGE.WARN.
         env_prefix (unicode): Prefix for environment variables, e.g.
             WASABI_LOG_FRIENDLY.
+        timestamp (bool): Print a timestamp (default False).
         RETURNS (Printer): The initialized printer.
         """
         env_log_friendly = os.getenv("{}_LOG_FRIENDLY".format(env_prefix), False)
@@ -55,6 +58,7 @@ class Printer(object):
         self.line_max = line_max
         self.colors = dict(COLORS)
         self.icons = dict(ICONS)
+        self.timestamp = timestamp
         if colors:
             self.colors.update(colors)
         if icons:
@@ -87,7 +91,7 @@ class Printer(object):
         )
 
     def info(self, title="", text="", show=True, spaced=False, exits=None):
-        """Print an error message."""
+        """Print an informational message."""
         return self._get_msg(
             title, text, style=MESSAGES.INFO, show=show, spaced=spaced, exits=exits
         )
@@ -127,6 +131,8 @@ class Printer(object):
             title = wrap(title, indent=0)
         if text:
             title = "{}\n{}".format(title, wrap(text, indent=0))
+        if self.timestamp:
+            title = "{}\t{}".format(datetime.datetime.now(), title)
         if exits is not None or spaced:
             title = "\n{}\n".format(title)
         if not self.no_print and not no_print:

--- a/wasabi/tests/test_printer.py
+++ b/wasabi/tests/test_printer.py
@@ -55,7 +55,7 @@ def test_printer_print():
 def test_printer_print_timestamp():
     p = Printer(no_print=True, timestamp=True)
     result = p.info("Hello world")
-    matches = re.match("^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}.*", result)
+    matches = re.match("^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}", result)
     assert matches
 
 

--- a/wasabi/tests/test_printer.py
+++ b/wasabi/tests/test_printer.py
@@ -169,7 +169,6 @@ def test_printer_log_friendly_prefix():
     del os.environ[ENV_LOG_FRIENDLY]
 
 
-@pytest.mark.skip(reason="Now seems to raise TypeError: readonly attribute?")
 def test_printer_none_encoding(monkeypatch):
     """Test that printer works even if sys.stdout.encoding is set to None. This
     previously caused a very confusing error."""

--- a/wasabi/tests/test_printer.py
+++ b/wasabi/tests/test_printer.py
@@ -169,6 +169,7 @@ def test_printer_log_friendly_prefix():
     del os.environ[ENV_LOG_FRIENDLY]
 
 
+@pytest.mark.skip(reason="Now seems to raise TypeError: readonly attribute?")
 def test_printer_none_encoding(monkeypatch):
     """Test that printer works even if sys.stdout.encoding is set to None. This
     previously caused a very confusing error."""

--- a/wasabi/tests/test_printer.py
+++ b/wasabi/tests/test_printer.py
@@ -42,7 +42,7 @@ def test_printer():
 
 
 def test_printer_print():
-    p = Printer()
+    p = Printer(timestamp=True)
     text = "This is a test."
     p.good(text)
     p.fail(text)

--- a/wasabi/tests/test_printer.py
+++ b/wasabi/tests/test_printer.py
@@ -1,6 +1,8 @@
 # coding: utf8
 from __future__ import unicode_literals, print_function
 
+import re
+
 import pytest
 import time
 import os
@@ -42,12 +44,19 @@ def test_printer():
 
 
 def test_printer_print():
-    p = Printer(timestamp=True)
+    p = Printer()
     text = "This is a test."
     p.good(text)
     p.fail(text)
     p.info(text)
     p.text(text)
+
+
+def test_printer_print_timestamp():
+    p = Printer(no_print=True, timestamp=True)
+    result = p.info("Hello world")
+    matches = re.match("^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}.*", result)
+    assert matches
 
 
 def test_printer_no_pretty():


### PR DESCRIPTION
`test_printer_print()` with `timestamp=True` gives:

```
2020-01-02 16:21:14.115112	✔ This is a test.
2020-01-02 16:21:14.115112	✘ This is a test.
2020-01-02 16:21:14.115112	ℹ This is a test.
2020-01-02 16:21:14.115112	This is a test.
```

~~I also removed a `skip` from a test because it was running just fine locally, will see what the CI thinks of it, maybe somehow magically this issue got resolved ?~~