### PR TITLE
added version to init

### DIFF
--- a/wasabi/__init__.py
+++ b/wasabi/__init__.py
@@ -7,5 +7,6 @@ from .traceback_printer import TracebackPrinter  # noqa
 from .markdown import MarkdownRenderer  # noqa
 from .util import color, wrap, get_raw_input, format_repr, diff_strings  # noqa
 from .util import MESSAGES  # noqa
+from .about import __version__  # noqa
 
 msg = Printer()


### PR DESCRIPTION
Added version to `__init__.py` so that version number is available using:

```
import wasabi
print(wasabi.__version__)
```

Have no idea what the #noqa does, but it seems to be required so added it as well.