### PR TITLE
Add color support for tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,8 @@ Column 1   Column 2    Column 3
 | `bg_colors` | iterable                | Background colors, one per column. None can be specified for individual columns to retain the default background color. | `None`   |
 | **RETURNS** | str                 | The formatted table.                                                                                                                |          |
 
+#### <kbd>function</kbd> `row`
+
 ```python
 from wasabi import row
 

--- a/README.md
+++ b/README.md
@@ -236,8 +236,8 @@ a1   a2   a3
 | `widths`    | list / int / `"auto"` | Column widths, either one integer for all columns or an iterable of values. If "auto", widths will be calculated automatically based on the largest value. | `"auto"` |
 | `spacing`   | int                       | Number of spaces between columns.                                                                                                                          | `3`      |
 | `aligns`    | list                  | Columns alignments in order. `"l"` (left), `"r"` (right) or `"c"` (center).                                                                                | `None`   |
-| `fg_colors`    | list                  | Foreground colors for the columns, in order, or None to retain the default foreground color.                                                                                | `None`   |
-| `bg_colors`    | list                  | Foreground colors for the columns, in order, or None to retain the default foreground color.                                                                                | `None`   |
+| `fg_colors`    | list                  | Foreground colors for the columns, in order. None can be specified for individual columns to retain the default foreground color.                                                                                | `None`   |
+| `bg_colors`    | list                  | Background colors for the columns, in order. None can be specified for individual columns to retain the default background color.                                                                                | `None`   |
 | **RETURNS** | str                       | The formatted row.                                                                                                                                         |          |
 ### <kbd>class</kbd> `TracebackPrinter`
 

--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ a1   a2   a3
 | `fg_colors`    | list                  | Foreground colors for the columns, in order. None can be specified for individual columns to retain the default foreground color. | `None`   |
 | `bg_colors`    | list                  | Background colors for the columns, in order. None can be specified for individual columns to retain the default background color. | `None`   |
 | **RETURNS** | str                       | The formatted row.                                                                                                                                         |          |
+
 ### <kbd>class</kbd> `TracebackPrinter`
 
 Helper to output custom formatted tracebacks and error messages. Currently used

--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@ a1   a2   a3
 | `widths`    | list / int / `"auto"` | Column widths, either one integer for all columns or an iterable of values. If "auto", widths will be calculated automatically based on the largest value. | `"auto"` |
 | `spacing`   | int                       | Number of spaces between columns.                                                                                                                          | `3`      |
 | `aligns`    | list                  | Columns alignments in order. `"l"` (left), `"r"` (right) or `"c"` (center).                                                                                | `None`   |
+| `env_prefix` | unicode                | Prefix for environment variables, e.g. WASABI_LOG_FRIENDLY.                                         | `"WASABI"` |
 | `fg_colors`    | list                  | Foreground colors for the columns, in order. None can be specified for individual columns to retain the default foreground color. | `None`   |
 | `bg_colors`    | list                  | Background colors for the columns, in order. None can be specified for individual columns to retain the default background color. | `None`   |
 | **RETURNS** | str                       | The formatted row.                                                                                                                                         |          |

--- a/README.md
+++ b/README.md
@@ -213,11 +213,10 @@ Column 1   Column 2    Column 3
 | `spacing`   | int                 | Number of spaces between columns.                                                                                                   | `3`      |
 | `aligns`    | iterable / unicode  | Columns alignments in order. `"l"` (left, default), `"r"` (right) or `"c"` (center). If If a string, value is used for all columns. | `None`   |
 | `multiline` | bool                | If a cell value is a list of a tuple, render it on multiple lines, with one value per line.                                         | `False`  |
-| `env_prefix` | unicode                | Prefix for environment variables, e.g.
-        WASABI_LOG_FRIENDLY.                                         |`"WASABI"`   |
-| `color_values` | dict                | Add or overwrite color values, name mapped to value.                                         |`None`   |
-| `fg_colors` | iterable                | Foreground colors, one per column.                                         |`None`   |
-| `bg_colors` | iterable                | Background colors, one per column.                                         |`None`   |
+| `env_prefix` | unicode                | Prefix for environment variables, e.g. WASABI_LOG_FRIENDLY.                                         | `"WASABI"` |
+| `color_values` | dict                | Add or overwrite color values, name mapped to value.                                         | `None`   |
+| `fg_colors` | iterable                | Foreground colors, one per column.                                         | `None`   |
+| `bg_colors` | iterable                | Background colors, one per column.                                         | `None`   |
 | **RETURNS** | str                 | The formatted table.                                                                                                                |          |
 
 ```python
@@ -237,10 +236,9 @@ a1   a2   a3
 | `widths`    | list / int / `"auto"` | Column widths, either one integer for all columns or an iterable of values. If "auto", widths will be calculated automatically based on the largest value. | `"auto"` |
 | `spacing`   | int                       | Number of spaces between columns.                                                                                                                          | `3`      |
 | `aligns`    | list                  | Columns alignments in order. `"l"` (left), `"r"` (right) or `"c"` (center).                                                                                | `None`   |
-| `fg_colors`    | list                  | Foreground colors for the columns, in order, or None
-        to retain the default foreground color.                                                                                | `None`   |
-| `bg_colors`    | list                  | Foreground colors for the columns, in order, or None
-        to retain the default foregrond color.                                                                                | `None`   || **RETURNS** | str                       | The formatted row.                                                                                                                                         |          |
+| `fg_colors`    | list                  | Foreground colors for the columns, in order, or None to retain the default foreground color.                                                                                | `None`   |
+| `bg_colors`    | list                  | Foreground colors for the columns, in order, or None to retain the default foreground color.                                                                                | `None`   |
+| **RETURNS** | str                       | The formatted row.                                                                                                                                         |          |
 ### <kbd>class</kbd> `TracebackPrinter`
 
 Helper to output custom formatted tracebacks and error messages. Currently used

--- a/README.md
+++ b/README.md
@@ -213,9 +213,12 @@ Column 1   Column 2    Column 3
 | `spacing`   | int                 | Number of spaces between columns.                                                                                                   | `3`      |
 | `aligns`    | iterable / unicode  | Columns alignments in order. `"l"` (left, default), `"r"` (right) or `"c"` (center). If If a string, value is used for all columns. | `None`   |
 | `multiline` | bool                | If a cell value is a list of a tuple, render it on multiple lines, with one value per line.                                         | `False`  |
+| `env_prefix` | unicode                | Prefix for environment variables, e.g.
+        WASABI_LOG_FRIENDLY.                                         |`"WASABI"`   |
+| `color_values` | dict                | Add or overwrite color values, name mapped to value.                                         |`None`   |
+| `fg_colors` | iterable                | Foreground colors, one per column.                                         |`None`   |
+| `bg_colors` | iterable                | Background colors, one per column.                                         |`None`   |
 | **RETURNS** | str                 | The formatted table.                                                                                                                |          |
-
-#### <kbd>function</kbd> `row`
 
 ```python
 from wasabi import row
@@ -231,11 +234,13 @@ a1   a2   a3
 | Argument    | Type                      | Description                                                                                                                                                | Default  |
 | ----------- | ------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
 | `data`      | iterable                  | The individual columns to format.                                                                                                                          |          |
-| `widths`    | iterable / int / `"auto"` | Column widths, either one integer for all columns or an iterable of values. If "auto", widths will be calculated automatically based on the largest value. | `"auto"` |
+| `widths`    | list / int / `"auto"` | Column widths, either one integer for all columns or an iterable of values. If "auto", widths will be calculated automatically based on the largest value. | `"auto"` |
 | `spacing`   | int                       | Number of spaces between columns.                                                                                                                          | `3`      |
-| `aligns`    | iterable                  | Columns alignments in order. `"l"` (left), `"r"` (right) or `"c"` (center).                                                                                | `None`   |
-| **RETURNS** | str                       | The formatted row.                                                                                                                                         |          |
-
+| `aligns`    | list                  | Columns alignments in order. `"l"` (left), `"r"` (right) or `"c"` (center).                                                                                | `None`   |
+| `fg_colors`    | list                  | Foreground colors for the columns, in order, or None
+        to retain the default foreground color.                                                                                | `None`   |
+| `bg_colors`    | list                  | Foreground colors for the columns, in order, or None
+        to retain the default foregrond color.                                                                                | `None`   || **RETURNS** | str                       | The formatted row.                                                                                                                                         |          |
 ### <kbd>class</kbd> `TracebackPrinter`
 
 Helper to output custom formatted tracebacks and error messages. Currently used

--- a/README.md
+++ b/README.md
@@ -215,8 +215,8 @@ Column 1   Column 2    Column 3
 | `multiline` | bool                | If a cell value is a list of a tuple, render it on multiple lines, with one value per line.                                         | `False`  |
 | `env_prefix` | unicode                | Prefix for environment variables, e.g. WASABI_LOG_FRIENDLY.                                         | `"WASABI"` |
 | `color_values` | dict                | Add or overwrite color values, name mapped to value.                                         | `None`   |
-| `fg_colors` | iterable                | Foreground colors, one per column.                                         | `None`   |
-| `bg_colors` | iterable                | Background colors, one per column.                                         | `None`   |
+| `fg_colors` | iterable                | Foreground colors, one per column. None can be specified for individual columns to retain the default background color. | `None`   |
+| `bg_colors` | iterable                | Background colors, one per column. None can be specified for individual columns to retain the default background color. | `None`   |
 | **RETURNS** | str                 | The formatted table.                                                                                                                |          |
 
 ```python
@@ -236,8 +236,8 @@ a1   a2   a3
 | `widths`    | list / int / `"auto"` | Column widths, either one integer for all columns or an iterable of values. If "auto", widths will be calculated automatically based on the largest value. | `"auto"` |
 | `spacing`   | int                       | Number of spaces between columns.                                                                                                                          | `3`      |
 | `aligns`    | list                  | Columns alignments in order. `"l"` (left), `"r"` (right) or `"c"` (center).                                                                                | `None`   |
-| `fg_colors`    | list                  | Foreground colors for the columns, in order. None can be specified for individual columns to retain the default foreground color.                                                                                | `None`   |
-| `bg_colors`    | list                  | Background colors for the columns, in order. None can be specified for individual columns to retain the default background color.                                                                                | `None`   |
+| `fg_colors`    | list                  | Foreground colors for the columns, in order. None can be specified for individual columns to retain the default foreground color. | `None`   |
+| `bg_colors`    | list                  | Background colors for the columns, in order. None can be specified for individual columns to retain the default background color. | `None`   |
 | **RETURNS** | str                       | The formatted row.                                                                                                                                         |          |
 ### <kbd>class</kbd> `TracebackPrinter`
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -63,6 +63,24 @@ jobs:
       Python38Mac:
         imageName: 'macos-10.14'
         python.version: '3.8'
+      Python39Linux:
+        imageName: 'ubuntu-20.04'
+        python.version: '3.9'
+      Python39Windows:
+        imageName: 'vs2017-win2016'
+        python.version: '3.9'
+      Python39Mac:
+        imageName: 'macos-10.14'
+        python.version: '3.9'
+      Python310Linux:
+        imageName: 'ubuntu-20.04'
+        python.version: '3.10'
+      Python310Windows:
+        imageName: 'vs2017-win2016'
+        python.version: '3.10'
+      Python310Mac:
+        imageName: 'macos-10.14'
+        python.version: '3.10'
     maxParallel: 4
   pool:
     vmImage: $(imageName)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,15 +10,15 @@ jobs:
   strategy:
     matrix:
       Python27Linux:
-        imageName: 'ubuntu-16.04'
+        imageName: 'ubuntu-20.04'
         python.version: '2.7'
       Python27LinuxASCII:
-        imageName: 'ubuntu-16.04'
+        imageName: 'ubuntu-20.04'
         python.version: '2.7'
         LANG: 'en_US.ascii'
         LC_ALL: 'en_US.ascii'
       Python27LinuxASCIIPython:
-        imageName: 'ubuntu-16.04'
+        imageName: 'ubuntu-20.04'
         python.version: '2.7'
         PYTHONIOENCODING: 'ascii'
       Python27Windows:
@@ -28,7 +28,7 @@ jobs:
         imageName: 'macos-10.14'
         python.version: '2.7'
       Python35Linux:
-        imageName: 'ubuntu-16.04'
+        imageName: 'ubuntu-20.04'
         python.version: '3.5'
       Python35Windows:
         imageName: 'vs2017-win2016'
@@ -37,7 +37,7 @@ jobs:
         imageName: 'macos-10.14'
         python.version: '3.5'
       Python36Linux:
-        imageName: 'ubuntu-16.04'
+        imageName: 'ubuntu-20.04'
         python.version: '3.6'
       Python36Windows:
         imageName: 'vs2017-win2016'
@@ -46,7 +46,7 @@ jobs:
         imageName: 'macos-10.14'
         python.version: '3.6'
       Python37Linux:
-        imageName: 'ubuntu-16.04'
+        imageName: 'ubuntu-20.04'
         python.version: '3.7'
       Python37Windows:
         imageName: 'vs2017-win2016'
@@ -55,7 +55,7 @@ jobs:
         imageName: 'macos-10.14'
         python.version: '3.7'
       Python38Linux:
-        imageName: 'ubuntu-16.04'
+        imageName: 'ubuntu-20.04'
         python.version: '3.8'
       Python38Windows:
         imageName: 'vs2017-win2016'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -78,9 +78,6 @@ jobs:
       Python310Windows:
         imageName: 'vs2017-win2016'
         python.version: '3.10'
-      Python310Mac:
-        imageName: 'macos-10.14'
-        python.version: '3.10'
     maxParallel: 4
   pool:
     vmImage: $(imageName)

--- a/wasabi/about.py
+++ b/wasabi/about.py
@@ -1,5 +1,5 @@
 __title__ = "wasabi"
-__version__ = "0.8.2"
+__version__ = "0.9.0"
 __summary__ = "A lightweight console printing and formatting toolkit"
 __uri__ = "https://ines.io"
 __author__ = "Ines Montani"

--- a/wasabi/printer.py
+++ b/wasabi/printer.py
@@ -123,7 +123,7 @@ class Printer(object):
         if not show:
             return
         if self.pretty:
-            color = self.colors.get(color)
+            color = self.colors.get(color) if color in self.colors else color
             icon = self.icons.get(icon)
             if icon:
                 title = locale_escape("{} {}".format(icon, title)).strip()

--- a/wasabi/printer.py
+++ b/wasabi/printer.py
@@ -102,6 +102,7 @@ class Printer(object):
         title="",
         text="",
         color=None,
+        bg_color=None,
         icon=None,
         spaced=False,
         show=True,
@@ -113,6 +114,7 @@ class Printer(object):
         title (unicode): The main text to print.
         text (unicode): Optional additional text to print.
         color (unicode / int): Foreground color.
+        bg_color (unicode / int): Background color.
         icon (unicode): Name of icon to add.
         spaced (unicode): Whether to add newlines around the output.
         show (bool): Whether to print or not. Can be used to only output
@@ -123,12 +125,13 @@ class Printer(object):
         if not show:
             return
         if self.pretty:
-            color = self.colors.get(color) if color in self.colors else color
+            color = self.colors.get(color, color)
+            bg_color = self.colors.get(bg_color, bg_color)
             icon = self.icons.get(icon)
             if icon:
                 title = locale_escape("{} {}".format(icon, title)).strip()
             if self.show_color:
-                title = _color(title, fg=color)
+                title = _color(title, fg=color, bg=bg_color)
             title = wrap(title, indent=0)
         if text:
             title = "{}\n{}".format(title, wrap(text, indent=0))

--- a/wasabi/tables.py
+++ b/wasabi/tables.py
@@ -43,18 +43,30 @@ def table(
         multiple lines, with one value per line.
     env_prefix (unicode): Prefix for environment variables, e.g.
         WASABI_LOG_FRIENDLY.
-      color_values (dict): Add or overwrite color values, name mapped to value.
+    color_values (dict): Add or overwrite color values, name mapped to value.
     fg_colors (iterable): Foreground colors, one per column.
     bg_colors (iterable): Background colors, one per column.
     RETURNS (unicode): The formatted table.
     """
     env_log_friendly = os.getenv("{}_LOG_FRIENDLY".format(env_prefix), False)
-    if supports_ansi() and not env_log_friendly and (fg_colors is not None or bg_colors is not None):
+    if (
+        supports_ansi()
+        and not env_log_friendly
+        and (fg_colors is not None or bg_colors is not None)
+    ):
         colors = dict(COLORS)
         if color_values is not None:
             colors.update(color_values)
-        fg_colors = [colors.get(fg_color) for fg_color in fg_colors]
-        bg_colors = [colors.get(bg_color) for bg_color in bg_colors]
+        if fg_colors is not None:
+            fg_colors = [
+                colors.get(fg_color) if fg_color in colors else fg_color
+                for fg_color in fg_colors
+            ]
+        if bg_colors is not None:
+            bg_colors = [
+                colors.get(bg_color) if bg_color in colors else bg_color
+                for bg_color in bg_colors
+            ]
     else:
         fg_colors = None
         bg_colors = None
@@ -70,8 +82,13 @@ def table(
         data = zipped_data
     if widths == "auto":
         widths = _get_max_widths(data, header, footer, max_col)
-    settings = {"widths": widths, "spacing": spacing, "aligns": aligns,
-        "fg_colors": fg_colors, "bg_colors": bg_colors}
+    settings = {
+        "widths": widths,
+        "spacing": spacing,
+        "aligns": aligns,
+        "fg_colors": fg_colors,
+        "bg_colors": bg_colors,
+    }
     divider_row = row(["-" * width for width in widths], **settings)
     rows = []
     if header:
@@ -91,15 +108,15 @@ def row(data, widths="auto", spacing=3, aligns=None, fg_colors=None, bg_colors=N
     """Format data as a table row.
 
     data (iterable): The individual columns to format.
-    widths (iterable, int or 'auto'): Column widths, either one integer for all
+    widths (list, int or 'auto'): Column widths, either one integer for all
         columns or an iterable of values. If "auto", widths will be calculated
         automatically based on the largest value.
     spacing (int): Spacing between columns, in spaces.
-    aligns (iterable / unicode): Column alignments in order. 'l' (left,
+    aligns (list / unicode): Column alignments in order. 'l' (left,
         default), 'r' (right) or 'c' (center). If a string, value is used
         for all columns.
     fg_colors (list): Foreground colors for the columns, in order, or None
-        to retain the default foreground color.  
+        to retain the default foreground color.
     bg_colors (list): Background colors for the columns, in order, or None
         to return the default background color.
     RETURNS (unicode): The formatted row.
@@ -115,7 +132,7 @@ def row(data, widths="auto", spacing=3, aligns=None, fg_colors=None, bg_colors=N
         tpl = "{:%s%d}" % (align, col_width)
         col = tpl.format(to_string(col))
         if fg_colors is not None or bg_colors is not None:
-            fg = fg_colors[i] if fg_colors is not None else None 
+            fg = fg_colors[i] if fg_colors is not None else None
             bg = bg_colors[i] if bg_colors is not None else None
             col = _color(col, fg=fg, bg=bg)
         cols.append(col)

--- a/wasabi/tables.py
+++ b/wasabi/tables.py
@@ -115,10 +115,10 @@ def row(data, widths="auto", spacing=3, aligns=None, fg_colors=None, bg_colors=N
     aligns (list / unicode): Column alignments in order. 'l' (left,
         default), 'r' (right) or 'c' (center). If a string, value is used
         for all columns.
-    fg_colors (list): Foreground colors for the columns, in order, or None
-        to retain the default foreground color.
-    bg_colors (list): Background colors for the columns, in order, or None
-        to return the default background color.
+    fg_colors (list): Foreground colors for the columns, in order. None can be
+        specified for individual columns to retain the default foreground color.
+    bg_colors (list): Background colors for the columns, in order. None can be
+        specified for individual columns to retain the default background color.
     RETURNS (unicode): The formatted row.
     """
     cols = []

--- a/wasabi/tables.py
+++ b/wasabi/tables.py
@@ -135,7 +135,7 @@ def row(
     cols = []
     if isinstance(aligns, basestring_):  # single align value
         aligns = [aligns for _ in data]
-    if not hasattr(widths, "__iter__"):  # single number
+    if not hasattr(widths, "__iter__") and widths != "auto":  # single number
         widths = [widths for _ in range(len(data))]
     for i, col in enumerate(data):
         align = ALIGN_MAP.get(aligns[i] if aligns and i < len(aligns) else "l")

--- a/wasabi/tables.py
+++ b/wasabi/tables.py
@@ -44,8 +44,10 @@ def table(
     env_prefix (unicode): Prefix for environment variables, e.g.
         WASABI_LOG_FRIENDLY.
     color_values (dict): Add or overwrite color values, name mapped to value.
-    fg_colors (iterable): Foreground colors, one per column.
-    bg_colors (iterable): Background colors, one per column.
+    fg_colors (iterable): Foreground colors, one per column. None can be specified 
+        for individual columns to retain the default foreground color.
+    bg_colors (iterable): Background colors, one per column. None can be specified 
+        for individual columns to retain the default background color.
     RETURNS (unicode): The formatted table.
     """
     env_log_friendly = os.getenv("{}_LOG_FRIENDLY".format(env_prefix), False)

--- a/wasabi/tables.py
+++ b/wasabi/tables.py
@@ -55,15 +55,9 @@ def table(
         if color_values is not None:
             colors.update(color_values)
         if fg_colors is not None:
-            fg_colors = [
-                colors.get(fg_color) if fg_color in colors else fg_color
-                for fg_color in fg_colors
-            ]
+            fg_colors = [colors.get(fg_color, fg_color) for fg_color in fg_colors]
         if bg_colors is not None:
-            bg_colors = [
-                colors.get(bg_color) if bg_color in colors else bg_color
-                for bg_color in bg_colors
-            ]
+            bg_colors = [colors.get(bg_color, bg_color) for bg_color in bg_colors]
     if isinstance(data, dict):
         data = list(data.items())
     if multiline:

--- a/wasabi/tests/test_printer.py
+++ b/wasabi/tests/test_printer.py
@@ -100,6 +100,39 @@ def test_color_as_int():
         assert result == "This is a text."
 
 
+def test_bg_color():
+    p = Printer(no_print=True)
+    text = "This is a text."
+    result = p.text(text, bg_color="red")
+    print(result)
+    if SUPPORTS_ANSI:
+        assert result == "\x1b[48;5;1mThis is a text.\x1b[0m"
+    else:
+        assert result == "This is a text."
+
+
+def test_bg_color_as_int():
+    p = Printer(no_print=True)
+    text = "This is a text."
+    result = p.text(text, bg_color=220)
+    print(result)
+    if SUPPORTS_ANSI:
+        assert result == "\x1b[48;5;220mThis is a text.\x1b[0m"
+    else:
+        assert result == "This is a text."
+
+
+def test_color_and_bc_color():
+    p = Printer(no_print=True)
+    text = "This is a text."
+    result = p.text(text, color="green", bg_color="yellow")
+    print(result)
+    if SUPPORTS_ANSI:
+        assert result == "\x1b[38;5;2;48;5;3mThis is a text.\x1b[0m"
+    else:
+        assert result == "This is a text."
+
+
 def test_printer_counts():
     p = Printer()
     text = "This is a test."

--- a/wasabi/tests/test_printer.py
+++ b/wasabi/tests/test_printer.py
@@ -90,6 +90,13 @@ def test_printer_custom():
         assert warning == "?? {}".format(text)
 
 
+def test_color_as_int():
+    p = Printer(no_print=True)
+    text = "This is a text."
+    result = p.text(text, color=220)
+    assert result == "\x1b[38;5;220mThis is a text.\x1b[0m"
+
+
 def test_printer_counts():
     p = Printer()
     text = "This is a test."

--- a/wasabi/tests/test_printer.py
+++ b/wasabi/tests/test_printer.py
@@ -94,7 +94,10 @@ def test_color_as_int():
     p = Printer(no_print=True)
     text = "This is a text."
     result = p.text(text, color=220)
-    assert result == "\x1b[38;5;220mThis is a text.\x1b[0m"
+    if SUPPORTS_ANSI:
+        assert result == "\x1b[38;5;220mThis is a text.\x1b[0m"
+    else:
+        assert result == "This is a text."
 
 
 def test_printer_counts():

--- a/wasabi/tests/test_tables.py
+++ b/wasabi/tests/test_tables.py
@@ -141,7 +141,10 @@ def test_colors_whole_table_only_fg_colors(data, header, footer, fg_colors):
         divider=True,
         fg_colors=fg_colors,
     )
-    assert result
+    assert (
+        result
+        == "\nCOL A            \x1b[38;5;3mCOL B\x1b[0m   \x1b[38;5;87mCOL 3     \x1b[0m\n--------------   \x1b[38;5;3m-----\x1b[0m   \x1b[38;5;87m----------\x1b[0m\nHello            \x1b[38;5;3mWorld\x1b[0m   \x1b[38;5;87m12344342  \x1b[0m\nThis is a test   \x1b[38;5;3mWorld\x1b[0m   \x1b[38;5;87m1234      \x1b[0m\n--------------   \x1b[38;5;3m-----\x1b[0m   \x1b[38;5;87m----------\x1b[0m\n                 \x1b[38;5;3m     \x1b[0m   \x1b[38;5;87m2030203.00\x1b[0m\n"
+    )
 
 
 def test_colors_whole_table_only_bg_colors(data, header, footer, bg_colors):
@@ -152,7 +155,10 @@ def test_colors_whole_table_only_bg_colors(data, header, footer, bg_colors):
         divider=True,
         bg_colors=bg_colors,
     )
-    assert result
+    assert (
+        result
+        == "\n\x1b[48;5;2mCOL A         \x1b[0m   \x1b[48;5;23mCOL B\x1b[0m   COL 3     \n\x1b[48;5;2m--------------\x1b[0m   \x1b[48;5;23m-----\x1b[0m   ----------\n\x1b[48;5;2mHello         \x1b[0m   \x1b[48;5;23mWorld\x1b[0m   12344342  \n\x1b[48;5;2mThis is a test\x1b[0m   \x1b[48;5;23mWorld\x1b[0m   1234      \n\x1b[48;5;2m--------------\x1b[0m   \x1b[48;5;23m-----\x1b[0m   ----------\n\x1b[48;5;2m              \x1b[0m   \x1b[48;5;23m     \x1b[0m   2030203.00\n"
+    )
 
 
 def test_colors_whole_table_with_supplied_spacing(
@@ -167,7 +173,10 @@ def test_colors_whole_table_with_supplied_spacing(
         bg_colors=bg_colors,
         spacing=5,
     )
-    assert result
+    assert (
+        result
+        == "\n\x1b[48;5;2mCOL A         \x1b[0m     \x1b[38;5;3;48;5;23mCOL B\x1b[0m     \x1b[38;5;87mCOL 3     \x1b[0m\n\x1b[48;5;2m--------------\x1b[0m     \x1b[38;5;3;48;5;23m-----\x1b[0m     \x1b[38;5;87m----------\x1b[0m\n\x1b[48;5;2mHello         \x1b[0m     \x1b[38;5;3;48;5;23mWorld\x1b[0m     \x1b[38;5;87m12344342  \x1b[0m\n\x1b[48;5;2mThis is a test\x1b[0m     \x1b[38;5;3;48;5;23mWorld\x1b[0m     \x1b[38;5;87m1234      \x1b[0m\n\x1b[48;5;2m--------------\x1b[0m     \x1b[38;5;3;48;5;23m-----\x1b[0m     \x1b[38;5;87m----------\x1b[0m\n\x1b[48;5;2m              \x1b[0m     \x1b[38;5;3;48;5;23m     \x1b[0m     \x1b[38;5;87m2030203.00\x1b[0m\n"
+    )
 
 
 def test_colors_whole_table_with_supplied_widths(
@@ -182,7 +191,10 @@ def test_colors_whole_table_with_supplied_widths(
         bg_colors=bg_colors,
         widths=(5, 2, 10),
     )
-    assert result
+    assert (
+        result
+        == "\n\x1b[48;5;2mCOL A\x1b[0m   \x1b[38;5;3;48;5;23mCOL B\x1b[0m   \x1b[38;5;87mCOL 3     \x1b[0m\n\x1b[48;5;2m-----\x1b[0m   \x1b[38;5;3;48;5;23m--\x1b[0m   \x1b[38;5;87m----------\x1b[0m\n\x1b[48;5;2mHello\x1b[0m   \x1b[38;5;3;48;5;23mWorld\x1b[0m   \x1b[38;5;87m12344342  \x1b[0m\n\x1b[48;5;2mThis is a test\x1b[0m   \x1b[38;5;3;48;5;23mWorld\x1b[0m   \x1b[38;5;87m1234      \x1b[0m\n\x1b[48;5;2m-----\x1b[0m   \x1b[38;5;3;48;5;23m--\x1b[0m   \x1b[38;5;87m----------\x1b[0m\n\x1b[48;5;2m     \x1b[0m   \x1b[38;5;3;48;5;23m  \x1b[0m   \x1b[38;5;87m2030203.00\x1b[0m\n"
+    )
 
 
 def test_colors_whole_table_with_single_alignment(
@@ -197,7 +209,10 @@ def test_colors_whole_table_with_single_alignment(
         bg_colors=bg_colors,
         aligns="r",
     )
-    assert result
+    assert (
+        result
+        == "\n\x1b[48;5;2m         COL A\x1b[0m   \x1b[38;5;3;48;5;23mCOL B\x1b[0m   \x1b[38;5;87m     COL 3\x1b[0m\n\x1b[48;5;2m--------------\x1b[0m   \x1b[38;5;3;48;5;23m-----\x1b[0m   \x1b[38;5;87m----------\x1b[0m\n\x1b[48;5;2m         Hello\x1b[0m   \x1b[38;5;3;48;5;23mWorld\x1b[0m   \x1b[38;5;87m  12344342\x1b[0m\n\x1b[48;5;2mThis is a test\x1b[0m   \x1b[38;5;3;48;5;23mWorld\x1b[0m   \x1b[38;5;87m      1234\x1b[0m\n\x1b[48;5;2m--------------\x1b[0m   \x1b[38;5;3;48;5;23m-----\x1b[0m   \x1b[38;5;87m----------\x1b[0m\n\x1b[48;5;2m              \x1b[0m   \x1b[38;5;3;48;5;23m     \x1b[0m   \x1b[38;5;87m2030203.00\x1b[0m\n"
+    )
 
 
 def test_colors_whole_table_with_multiple_alignment(
@@ -212,7 +227,10 @@ def test_colors_whole_table_with_multiple_alignment(
         bg_colors=bg_colors,
         aligns=("c", "r", "l"),
     )
-    assert result
+    assert (
+        result
+        == "\n\x1b[48;5;2m    COL A     \x1b[0m   \x1b[38;5;3;48;5;23mCOL B\x1b[0m   \x1b[38;5;87mCOL 3     \x1b[0m\n\x1b[48;5;2m--------------\x1b[0m   \x1b[38;5;3;48;5;23m-----\x1b[0m   \x1b[38;5;87m----------\x1b[0m\n\x1b[48;5;2m    Hello     \x1b[0m   \x1b[38;5;3;48;5;23mWorld\x1b[0m   \x1b[38;5;87m12344342  \x1b[0m\n\x1b[48;5;2mThis is a test\x1b[0m   \x1b[38;5;3;48;5;23mWorld\x1b[0m   \x1b[38;5;87m1234      \x1b[0m\n\x1b[48;5;2m--------------\x1b[0m   \x1b[38;5;3;48;5;23m-----\x1b[0m   \x1b[38;5;87m----------\x1b[0m\n\x1b[48;5;2m              \x1b[0m   \x1b[38;5;3;48;5;23m     \x1b[0m   \x1b[38;5;87m2030203.00\x1b[0m\n"
+    )
 
 
 def test_colors_whole_table_with_multiline(data, header, footer, fg_colors, bg_colors):
@@ -222,7 +240,10 @@ def test_colors_whole_table_with_multiline(data, header, footer, fg_colors, bg_c
         bg_colors=bg_colors,
         multiline=True,
     )
-    assert result
+    assert (
+        result
+        == "\n\x1b[48;5;2mCharles\x1b[0m   \x1b[38;5;3;48;5;23mmy\x1b[0m   \x1b[38;5;87mbrother\x1b[0m\n\x1b[48;5;2mQuinton\x1b[0m   \x1b[38;5;3;48;5;23m  \x1b[0m   \x1b[38;5;87m       \x1b[0m\n\x1b[48;5;2mMurphy \x1b[0m   \x1b[38;5;3;48;5;23m  \x1b[0m   \x1b[38;5;87m       \x1b[0m\n\x1b[48;5;2m       \x1b[0m   \x1b[38;5;3;48;5;23m  \x1b[0m   \x1b[38;5;87m       \x1b[0m\n\x1b[48;5;2m1      \x1b[0m   \x1b[38;5;3;48;5;23m2 \x1b[0m   \x1b[38;5;87m3      \x1b[0m\n"
+    )
 
 
 def test_colors_whole_table_log_friendly(data, header, footer, fg_colors, bg_colors):
@@ -293,4 +314,7 @@ def test_colors_whole_table_color_values(data, header, footer, fg_colors, bg_col
         bg_colors=bg_colors,
         color_values={"yellow": 11},
     )
-    assert result
+    assert (
+        result
+        == "\n\x1b[48;5;2mCOL A         \x1b[0m   \x1b[38;5;11;48;5;23mCOL B\x1b[0m   \x1b[38;5;87mCOL 3     \x1b[0m\n\x1b[48;5;2m--------------\x1b[0m   \x1b[38;5;11;48;5;23m-----\x1b[0m   \x1b[38;5;87m----------\x1b[0m\n\x1b[48;5;2mHello         \x1b[0m   \x1b[38;5;11;48;5;23mWorld\x1b[0m   \x1b[38;5;87m12344342  \x1b[0m\n\x1b[48;5;2mThis is a test\x1b[0m   \x1b[38;5;11;48;5;23mWorld\x1b[0m   \x1b[38;5;87m1234      \x1b[0m\n\x1b[48;5;2m--------------\x1b[0m   \x1b[38;5;11;48;5;23m-----\x1b[0m   \x1b[38;5;87m----------\x1b[0m\n\x1b[48;5;2m              \x1b[0m   \x1b[38;5;11;48;5;23m     \x1b[0m   \x1b[38;5;87m2030203.00\x1b[0m\n"
+    )

--- a/wasabi/tests/test_tables.py
+++ b/wasabi/tests/test_tables.py
@@ -121,7 +121,9 @@ def test_row_fg_colors_and_bg_colors(fg_colors, bg_colors):
     )
 
 
-def test_colors_whole_table_with_automatic_widths(data, header, footer, fg_colors, bg_colors):
+def test_colors_whole_table_with_automatic_widths(
+    data, header, footer, fg_colors, bg_colors
+):
     result = table(
         data,
         header=header,
@@ -132,11 +134,35 @@ def test_colors_whole_table_with_automatic_widths(data, header, footer, fg_color
     )
     assert (
         result
-        == "\n\x1b[48;5;2mCOL A         \x1b[0m   \x1b[38;5;3mCOL B\x1b[0m   COL 3     \n\x1b[48;5;2m--------------\x1b[0m   \x1b[38;5;3m-----\x1b[0m   ----------\n\x1b[48;5;2mHello         \x1b[0m   \x1b[38;5;3mWorld\x1b[0m   12344342  \n\x1b[48;5;2mThis is a test\x1b[0m   \x1b[38;5;3mWorld\x1b[0m   1234      \n\x1b[48;5;2m--------------\x1b[0m   \x1b[38;5;3m-----\x1b[0m   ----------\n\x1b[48;5;2m              \x1b[0m   \x1b[38;5;3m     \x1b[0m   2030203.00\n"
+        == "\n\x1b[48;5;2mCOL A         \x1b[0m   \x1b[38;5;3;48;5;23mCOL B\x1b[0m   \x1b[38;5;87mCOL 3     \x1b[0m\n\x1b[48;5;2m--------------\x1b[0m   \x1b[38;5;3;48;5;23m-----\x1b[0m   \x1b[38;5;87m----------\x1b[0m\n\x1b[48;5;2mHello         \x1b[0m   \x1b[38;5;3;48;5;23mWorld\x1b[0m   \x1b[38;5;87m12344342  \x1b[0m\n\x1b[48;5;2mThis is a test\x1b[0m   \x1b[38;5;3;48;5;23mWorld\x1b[0m   \x1b[38;5;87m1234      \x1b[0m\n\x1b[48;5;2m--------------\x1b[0m   \x1b[38;5;3;48;5;23m-----\x1b[0m   \x1b[38;5;87m----------\x1b[0m\n\x1b[48;5;2m              \x1b[0m   \x1b[38;5;3;48;5;23m     \x1b[0m   \x1b[38;5;87m2030203.00\x1b[0m\n"
     )
 
 
-def test_colors_whole_table_with_supplied_spacing(data, header, footer, fg_colors, bg_colors):
+def test_colors_whole_table_only_fg_colors(data, header, footer, fg_colors):
+    result = table(
+        data,
+        header=header,
+        footer=footer,
+        divider=True,
+        fg_colors=fg_colors,
+    )
+    assert result
+
+
+def test_colors_whole_table_only_bg_colors(data, header, footer, bg_colors):
+    result = table(
+        data,
+        header=header,
+        footer=footer,
+        divider=True,
+        bg_colors=bg_colors,
+    )
+    assert result
+
+
+def test_colors_whole_table_with_supplied_spacing(
+    data, header, footer, fg_colors, bg_colors
+):
     result = table(
         data,
         header=header,
@@ -144,14 +170,14 @@ def test_colors_whole_table_with_supplied_spacing(data, header, footer, fg_color
         divider=True,
         fg_colors=fg_colors,
         bg_colors=bg_colors,
-        spacing=5   
+        spacing=5,
     )
-    assert (
-        result
-        == "\n\x1b[48;5;2mCOL A         \x1b[0m     \x1b[38;5;3mCOL B\x1b[0m     COL 3     \n\x1b[48;5;2m--------------\x1b[0m     \x1b[38;5;3m-----\x1b[0m     ----------\n\x1b[48;5;2mHello         \x1b[0m     \x1b[38;5;3mWorld\x1b[0m     12344342  \n\x1b[48;5;2mThis is a test\x1b[0m     \x1b[38;5;3mWorld\x1b[0m     1234      \n\x1b[48;5;2m--------------\x1b[0m     \x1b[38;5;3m-----\x1b[0m     ----------\n\x1b[48;5;2m              \x1b[0m     \x1b[38;5;3m     \x1b[0m     2030203.00\n"
-    )
+    assert result
 
-def test_colors_whole_table_with_supplied_widths(data, header, footer, fg_colors, bg_colors):
+
+def test_colors_whole_table_with_supplied_widths(
+    data, header, footer, fg_colors, bg_colors
+):
     result = table(
         data,
         header=header,
@@ -159,14 +185,14 @@ def test_colors_whole_table_with_supplied_widths(data, header, footer, fg_colors
         divider=True,
         fg_colors=fg_colors,
         bg_colors=bg_colors,
-        widths=(5,2,10)
+        widths=(5, 2, 10),
     )
-    assert (
-        result
-        == "\n\x1b[48;5;2mCOL A\x1b[0m   \x1b[38;5;3mCOL B\x1b[0m   COL 3     \n\x1b[48;5;2m-----\x1b[0m   \x1b[38;5;3m--\x1b[0m   ----------\n\x1b[48;5;2mHello\x1b[0m   \x1b[38;5;3mWorld\x1b[0m   12344342  \n\x1b[48;5;2mThis is a test\x1b[0m   \x1b[38;5;3mWorld\x1b[0m   1234      \n\x1b[48;5;2m-----\x1b[0m   \x1b[38;5;3m--\x1b[0m   ----------\n\x1b[48;5;2m     \x1b[0m   \x1b[38;5;3m  \x1b[0m   2030203.00\n"
-    )
+    assert result
 
-def test_colors_whole_table_with_single_alignment(data, header, footer, fg_colors, bg_colors):
+
+def test_colors_whole_table_with_single_alignment(
+    data, header, footer, fg_colors, bg_colors
+):
     result = table(
         data,
         header=header,
@@ -174,14 +200,14 @@ def test_colors_whole_table_with_single_alignment(data, header, footer, fg_color
         divider=True,
         fg_colors=fg_colors,
         bg_colors=bg_colors,
-        aligns='r'
+        aligns="r",
     )
-    assert (
-        result
-        == "\n\x1b[48;5;2m         COL A\x1b[0m   \x1b[38;5;3mCOL B\x1b[0m        COL 3\n\x1b[48;5;2m--------------\x1b[0m   \x1b[38;5;3m-----\x1b[0m   ----------\n\x1b[48;5;2m         Hello\x1b[0m   \x1b[38;5;3mWorld\x1b[0m     12344342\n\x1b[48;5;2mThis is a test\x1b[0m   \x1b[38;5;3mWorld\x1b[0m         1234\n\x1b[48;5;2m--------------\x1b[0m   \x1b[38;5;3m-----\x1b[0m   ----------\n\x1b[48;5;2m              \x1b[0m   \x1b[38;5;3m     \x1b[0m   2030203.00\n"
-    )
+    assert result
 
-def test_colors_whole_table_with_multiple_alignment(data, header, footer, fg_colors, bg_colors):
+
+def test_colors_whole_table_with_multiple_alignment(
+    data, header, footer, fg_colors, bg_colors
+):
     result = table(
         data,
         header=header,
@@ -189,24 +215,20 @@ def test_colors_whole_table_with_multiple_alignment(data, header, footer, fg_col
         divider=True,
         fg_colors=fg_colors,
         bg_colors=bg_colors,
-        aligns=('c', 'r', 'l')
+        aligns=("c", "r", "l"),
     )
-    assert (
-        result
-        == "\n\x1b[48;5;2m    COL A     \x1b[0m   \x1b[38;5;3mCOL B\x1b[0m   COL 3     \n\x1b[48;5;2m--------------\x1b[0m   \x1b[38;5;3m-----\x1b[0m   ----------\n\x1b[48;5;2m    Hello     \x1b[0m   \x1b[38;5;3mWorld\x1b[0m   12344342  \n\x1b[48;5;2mThis is a test\x1b[0m   \x1b[38;5;3mWorld\x1b[0m   1234      \n\x1b[48;5;2m--------------\x1b[0m   \x1b[38;5;3m-----\x1b[0m   ----------\n\x1b[48;5;2m              \x1b[0m   \x1b[38;5;3m     \x1b[0m   2030203.00\n"
-    )
+    assert result
+
 
 def test_colors_whole_table_with_multiline(data, header, footer, fg_colors, bg_colors):
     result = table(
-        data = ((['Charles', 'Quinton', 'Murphy'], 'my', 'brother'), ('1', '2', '3')),
+        data=((["Charles", "Quinton", "Murphy"], "my", "brother"), ("1", "2", "3")),
         fg_colors=fg_colors,
         bg_colors=bg_colors,
-        multiline=True
+        multiline=True,
     )
-    assert (
-        result
-        == "\n\x1b[48;5;2mCharles\x1b[0m   \x1b[38;5;3mmy\x1b[0m   brother\n\x1b[48;5;2mQuinton\x1b[0m   \x1b[38;5;3m  \x1b[0m          \n\x1b[48;5;2mMurphy \x1b[0m   \x1b[38;5;3m  \x1b[0m          \n\x1b[48;5;2m       \x1b[0m   \x1b[38;5;3m  \x1b[0m          \n\x1b[48;5;2m1      \x1b[0m   \x1b[38;5;3m2 \x1b[0m   3      \n"
-    )
+    assert result
+
 
 def test_colors_whole_table_log_friendly(data, header, footer, fg_colors, bg_colors):
     ENV_LOG_FRIENDLY = "WASABI_LOG_FRIENDLY"
@@ -226,7 +248,9 @@ def test_colors_whole_table_log_friendly(data, header, footer, fg_colors, bg_col
     del os.environ[ENV_LOG_FRIENDLY]
 
 
-def test_colors_whole_table_log_friendly_prefix(data, header, footer, fg_colors, bg_colors):
+def test_colors_whole_table_log_friendly_prefix(
+    data, header, footer, fg_colors, bg_colors
+):
     ENV_LOG_FRIENDLY = "CUSTOM_LOG_FRIENDLY"
     os.environ[ENV_LOG_FRIENDLY] = "True"
     result = table(
@@ -236,7 +260,7 @@ def test_colors_whole_table_log_friendly_prefix(data, header, footer, fg_colors,
         divider=True,
         fg_colors=fg_colors,
         bg_colors=bg_colors,
-        env_prefix='CUSTOM'
+        env_prefix="CUSTOM",
     )
     assert (
         result
@@ -244,8 +268,11 @@ def test_colors_whole_table_log_friendly_prefix(data, header, footer, fg_colors,
     )
     del os.environ[ENV_LOG_FRIENDLY]
 
-def test_colors_whole_table_supports_ansi_false(data, header, footer, fg_colors, bg_colors):
-    os.environ['ANSI_COLORS_DISABLED'] = "True"
+
+def test_colors_whole_table_supports_ansi_false(
+    data, header, footer, fg_colors, bg_colors
+):
+    os.environ["ANSI_COLORS_DISABLED"] = "True"
     result = table(
         data,
         header=header,
@@ -258,7 +285,8 @@ def test_colors_whole_table_supports_ansi_false(data, header, footer, fg_colors,
         result
         == "\nCOL A            COL B   COL 3     \n--------------   -----   ----------\nHello            World   12344342  \nThis is a test   World   1234      \n--------------   -----   ----------\n                         2030203.00\n"
     )
-    del os.environ['ANSI_COLORS_DISABLED']
+    del os.environ["ANSI_COLORS_DISABLED"]
+
 
 def test_colors_whole_table_color_values(data, header, footer, fg_colors, bg_colors):
     result = table(
@@ -268,9 +296,6 @@ def test_colors_whole_table_color_values(data, header, footer, fg_colors, bg_col
         divider=True,
         fg_colors=fg_colors,
         bg_colors=bg_colors,
-        color_values= {'yellow': 11}
+        color_values={"yellow": 11},
     )
-    assert (
-        result
-        == "\n\x1b[48;5;2mCOL A         \x1b[0m   \x1b[38;5;11mCOL B\x1b[0m   COL 3     \n\x1b[48;5;2m--------------\x1b[0m   \x1b[38;5;11m-----\x1b[0m   ----------\n\x1b[48;5;2mHello         \x1b[0m   \x1b[38;5;11mWorld\x1b[0m   12344342  \n\x1b[48;5;2mThis is a test\x1b[0m   \x1b[38;5;11mWorld\x1b[0m   1234      \n\x1b[48;5;2m--------------\x1b[0m   \x1b[38;5;11m-----\x1b[0m   ----------\n\x1b[48;5;2m              \x1b[0m   \x1b[38;5;11m     \x1b[0m   2030203.00\n"
-    )
+    assert result

--- a/wasabi/tests/test_tables.py
+++ b/wasabi/tests/test_tables.py
@@ -31,11 +31,6 @@ def bg_colors():
     return ["green", "23", ""]
 
 
-@pytest.fixture()
-def color_values():
-    return {"red": 76}
-
-
 def test_table_default(data):
     result = table(data)
     assert (

--- a/wasabi/tests/test_tables.py
+++ b/wasabi/tests/test_tables.py
@@ -4,6 +4,9 @@ from __future__ import unicode_literals, print_function
 import os
 import pytest
 from wasabi.tables import table, row
+from wasabi.util import supports_ansi
+
+SUPPORTS_ANSI = supports_ansi()
 
 
 @pytest.fixture()
@@ -98,22 +101,35 @@ def test_table_multiline(header):
 
 def test_row_fg_colors(fg_colors):
     result = row(("Hello", "World", "12344342"), fg_colors=fg_colors)
-    assert result == "Hello   \x1b[38;5;3mWorld\x1b[0m   \x1b[38;5;87m12344342\x1b[0m"
+    if SUPPORTS_ANSI:
+        assert (
+            result == "Hello   \x1b[38;5;3mWorld\x1b[0m   \x1b[38;5;87m12344342\x1b[0m"
+        )
+    else:
+        assert result == "Hello   World   12344342"
 
 
 def test_row_bg_colors(bg_colors):
     result = row(("Hello", "World", "12344342"), bg_colors=bg_colors)
-    assert result == "\x1b[48;5;2mHello\x1b[0m   \x1b[48;5;23mWorld\x1b[0m   12344342"
+    if SUPPORTS_ANSI:
+        assert (
+            result == "\x1b[48;5;2mHello\x1b[0m   \x1b[48;5;23mWorld\x1b[0m   12344342"
+        )
+    else:
+        assert result == "Hello   World   12344342"
 
 
 def test_row_fg_colors_and_bg_colors(fg_colors, bg_colors):
     result = row(
         ("Hello", "World", "12344342"), fg_colors=fg_colors, bg_colors=bg_colors
     )
-    assert (
-        result
-        == "\x1b[48;5;2mHello\x1b[0m   \x1b[38;5;3;48;5;23mWorld\x1b[0m   \x1b[38;5;87m12344342\x1b[0m"
-    )
+    if SUPPORTS_ANSI:
+        assert (
+            result
+            == "\x1b[48;5;2mHello\x1b[0m   \x1b[38;5;3;48;5;23mWorld\x1b[0m   \x1b[38;5;87m12344342\x1b[0m"
+        )
+    else:
+        assert result == "Hello   World   12344342"
 
 
 def test_colors_whole_table_with_automatic_widths(
@@ -127,10 +143,16 @@ def test_colors_whole_table_with_automatic_widths(
         fg_colors=fg_colors,
         bg_colors=bg_colors,
     )
-    assert (
-        result
-        == "\n\x1b[48;5;2mCOL A         \x1b[0m   \x1b[38;5;3;48;5;23mCOL B\x1b[0m   \x1b[38;5;87mCOL 3     \x1b[0m\n\x1b[48;5;2m--------------\x1b[0m   \x1b[38;5;3;48;5;23m-----\x1b[0m   \x1b[38;5;87m----------\x1b[0m\n\x1b[48;5;2mHello         \x1b[0m   \x1b[38;5;3;48;5;23mWorld\x1b[0m   \x1b[38;5;87m12344342  \x1b[0m\n\x1b[48;5;2mThis is a test\x1b[0m   \x1b[38;5;3;48;5;23mWorld\x1b[0m   \x1b[38;5;87m1234      \x1b[0m\n\x1b[48;5;2m--------------\x1b[0m   \x1b[38;5;3;48;5;23m-----\x1b[0m   \x1b[38;5;87m----------\x1b[0m\n\x1b[48;5;2m              \x1b[0m   \x1b[38;5;3;48;5;23m     \x1b[0m   \x1b[38;5;87m2030203.00\x1b[0m\n"
-    )
+    if SUPPORTS_ANSI:
+        assert (
+            result
+            == "\n\x1b[48;5;2mCOL A         \x1b[0m   \x1b[38;5;3;48;5;23mCOL B\x1b[0m   \x1b[38;5;87mCOL 3     \x1b[0m\n\x1b[48;5;2m--------------\x1b[0m   \x1b[38;5;3;48;5;23m-----\x1b[0m   \x1b[38;5;87m----------\x1b[0m\n\x1b[48;5;2mHello         \x1b[0m   \x1b[38;5;3;48;5;23mWorld\x1b[0m   \x1b[38;5;87m12344342  \x1b[0m\n\x1b[48;5;2mThis is a test\x1b[0m   \x1b[38;5;3;48;5;23mWorld\x1b[0m   \x1b[38;5;87m1234      \x1b[0m\n\x1b[48;5;2m--------------\x1b[0m   \x1b[38;5;3;48;5;23m-----\x1b[0m   \x1b[38;5;87m----------\x1b[0m\n\x1b[48;5;2m              \x1b[0m   \x1b[38;5;3;48;5;23m     \x1b[0m   \x1b[38;5;87m2030203.00\x1b[0m\n"
+        )
+    else:
+        assert (
+            result
+            == "\nCOL A            COL B   COL 3     \n--------------   -----   ----------\nHello            World   12344342  \nThis is a test   World   1234      \n--------------   -----   ----------\n                         2030203.00\n"
+        )
 
 
 def test_colors_whole_table_only_fg_colors(data, header, footer, fg_colors):
@@ -141,10 +163,16 @@ def test_colors_whole_table_only_fg_colors(data, header, footer, fg_colors):
         divider=True,
         fg_colors=fg_colors,
     )
-    assert (
-        result
-        == "\nCOL A            \x1b[38;5;3mCOL B\x1b[0m   \x1b[38;5;87mCOL 3     \x1b[0m\n--------------   \x1b[38;5;3m-----\x1b[0m   \x1b[38;5;87m----------\x1b[0m\nHello            \x1b[38;5;3mWorld\x1b[0m   \x1b[38;5;87m12344342  \x1b[0m\nThis is a test   \x1b[38;5;3mWorld\x1b[0m   \x1b[38;5;87m1234      \x1b[0m\n--------------   \x1b[38;5;3m-----\x1b[0m   \x1b[38;5;87m----------\x1b[0m\n                 \x1b[38;5;3m     \x1b[0m   \x1b[38;5;87m2030203.00\x1b[0m\n"
-    )
+    if SUPPORTS_ANSI:
+        assert (
+            result
+            == "\nCOL A            \x1b[38;5;3mCOL B\x1b[0m   \x1b[38;5;87mCOL 3     \x1b[0m\n--------------   \x1b[38;5;3m-----\x1b[0m   \x1b[38;5;87m----------\x1b[0m\nHello            \x1b[38;5;3mWorld\x1b[0m   \x1b[38;5;87m12344342  \x1b[0m\nThis is a test   \x1b[38;5;3mWorld\x1b[0m   \x1b[38;5;87m1234      \x1b[0m\n--------------   \x1b[38;5;3m-----\x1b[0m   \x1b[38;5;87m----------\x1b[0m\n                 \x1b[38;5;3m     \x1b[0m   \x1b[38;5;87m2030203.00\x1b[0m\n"
+        )
+    else:
+        assert (
+            result
+            == "\nCOL A            COL B   COL 3     \n--------------   -----   ----------\nHello            World   12344342  \nThis is a test   World   1234      \n--------------   -----   ----------\n                         2030203.00\n"
+        )
 
 
 def test_colors_whole_table_only_bg_colors(data, header, footer, bg_colors):
@@ -155,10 +183,16 @@ def test_colors_whole_table_only_bg_colors(data, header, footer, bg_colors):
         divider=True,
         bg_colors=bg_colors,
     )
-    assert (
-        result
-        == "\n\x1b[48;5;2mCOL A         \x1b[0m   \x1b[48;5;23mCOL B\x1b[0m   COL 3     \n\x1b[48;5;2m--------------\x1b[0m   \x1b[48;5;23m-----\x1b[0m   ----------\n\x1b[48;5;2mHello         \x1b[0m   \x1b[48;5;23mWorld\x1b[0m   12344342  \n\x1b[48;5;2mThis is a test\x1b[0m   \x1b[48;5;23mWorld\x1b[0m   1234      \n\x1b[48;5;2m--------------\x1b[0m   \x1b[48;5;23m-----\x1b[0m   ----------\n\x1b[48;5;2m              \x1b[0m   \x1b[48;5;23m     \x1b[0m   2030203.00\n"
-    )
+    if SUPPORTS_ANSI:
+        assert (
+            result
+            == "\n\x1b[48;5;2mCOL A         \x1b[0m   \x1b[48;5;23mCOL B\x1b[0m   COL 3     \n\x1b[48;5;2m--------------\x1b[0m   \x1b[48;5;23m-----\x1b[0m   ----------\n\x1b[48;5;2mHello         \x1b[0m   \x1b[48;5;23mWorld\x1b[0m   12344342  \n\x1b[48;5;2mThis is a test\x1b[0m   \x1b[48;5;23mWorld\x1b[0m   1234      \n\x1b[48;5;2m--------------\x1b[0m   \x1b[48;5;23m-----\x1b[0m   ----------\n\x1b[48;5;2m              \x1b[0m   \x1b[48;5;23m     \x1b[0m   2030203.00\n"
+        )
+    else:
+        assert (
+            result
+            == "\nCOL A            COL B   COL 3     \n--------------   -----   ----------\nHello            World   12344342  \nThis is a test   World   1234      \n--------------   -----   ----------\n                         2030203.00\n"
+        )
 
 
 def test_colors_whole_table_with_supplied_spacing(
@@ -173,10 +207,16 @@ def test_colors_whole_table_with_supplied_spacing(
         bg_colors=bg_colors,
         spacing=5,
     )
-    assert (
-        result
-        == "\n\x1b[48;5;2mCOL A         \x1b[0m     \x1b[38;5;3;48;5;23mCOL B\x1b[0m     \x1b[38;5;87mCOL 3     \x1b[0m\n\x1b[48;5;2m--------------\x1b[0m     \x1b[38;5;3;48;5;23m-----\x1b[0m     \x1b[38;5;87m----------\x1b[0m\n\x1b[48;5;2mHello         \x1b[0m     \x1b[38;5;3;48;5;23mWorld\x1b[0m     \x1b[38;5;87m12344342  \x1b[0m\n\x1b[48;5;2mThis is a test\x1b[0m     \x1b[38;5;3;48;5;23mWorld\x1b[0m     \x1b[38;5;87m1234      \x1b[0m\n\x1b[48;5;2m--------------\x1b[0m     \x1b[38;5;3;48;5;23m-----\x1b[0m     \x1b[38;5;87m----------\x1b[0m\n\x1b[48;5;2m              \x1b[0m     \x1b[38;5;3;48;5;23m     \x1b[0m     \x1b[38;5;87m2030203.00\x1b[0m\n"
-    )
+    if SUPPORTS_ANSI:
+        assert (
+            result
+            == "\n\x1b[48;5;2mCOL A         \x1b[0m     \x1b[38;5;3;48;5;23mCOL B\x1b[0m     \x1b[38;5;87mCOL 3     \x1b[0m\n\x1b[48;5;2m--------------\x1b[0m     \x1b[38;5;3;48;5;23m-----\x1b[0m     \x1b[38;5;87m----------\x1b[0m\n\x1b[48;5;2mHello         \x1b[0m     \x1b[38;5;3;48;5;23mWorld\x1b[0m     \x1b[38;5;87m12344342  \x1b[0m\n\x1b[48;5;2mThis is a test\x1b[0m     \x1b[38;5;3;48;5;23mWorld\x1b[0m     \x1b[38;5;87m1234      \x1b[0m\n\x1b[48;5;2m--------------\x1b[0m     \x1b[38;5;3;48;5;23m-----\x1b[0m     \x1b[38;5;87m----------\x1b[0m\n\x1b[48;5;2m              \x1b[0m     \x1b[38;5;3;48;5;23m     \x1b[0m     \x1b[38;5;87m2030203.00\x1b[0m\n"
+        )
+    else:
+        assert (
+            result
+            == "\nCOL A              COL B     COL 3     \n--------------     -----     ----------\nHello              World     12344342  \nThis is a test     World     1234      \n--------------     -----     ----------\n                             2030203.00\n"
+        )
 
 
 def test_colors_whole_table_with_supplied_widths(
@@ -191,10 +231,16 @@ def test_colors_whole_table_with_supplied_widths(
         bg_colors=bg_colors,
         widths=(5, 2, 10),
     )
-    assert (
-        result
-        == "\n\x1b[48;5;2mCOL A\x1b[0m   \x1b[38;5;3;48;5;23mCOL B\x1b[0m   \x1b[38;5;87mCOL 3     \x1b[0m\n\x1b[48;5;2m-----\x1b[0m   \x1b[38;5;3;48;5;23m--\x1b[0m   \x1b[38;5;87m----------\x1b[0m\n\x1b[48;5;2mHello\x1b[0m   \x1b[38;5;3;48;5;23mWorld\x1b[0m   \x1b[38;5;87m12344342  \x1b[0m\n\x1b[48;5;2mThis is a test\x1b[0m   \x1b[38;5;3;48;5;23mWorld\x1b[0m   \x1b[38;5;87m1234      \x1b[0m\n\x1b[48;5;2m-----\x1b[0m   \x1b[38;5;3;48;5;23m--\x1b[0m   \x1b[38;5;87m----------\x1b[0m\n\x1b[48;5;2m     \x1b[0m   \x1b[38;5;3;48;5;23m  \x1b[0m   \x1b[38;5;87m2030203.00\x1b[0m\n"
-    )
+    if SUPPORTS_ANSI:
+        assert (
+            result
+            == "\n\x1b[48;5;2mCOL A\x1b[0m   \x1b[38;5;3;48;5;23mCOL B\x1b[0m   \x1b[38;5;87mCOL 3     \x1b[0m\n\x1b[48;5;2m-----\x1b[0m   \x1b[38;5;3;48;5;23m--\x1b[0m   \x1b[38;5;87m----------\x1b[0m\n\x1b[48;5;2mHello\x1b[0m   \x1b[38;5;3;48;5;23mWorld\x1b[0m   \x1b[38;5;87m12344342  \x1b[0m\n\x1b[48;5;2mThis is a test\x1b[0m   \x1b[38;5;3;48;5;23mWorld\x1b[0m   \x1b[38;5;87m1234      \x1b[0m\n\x1b[48;5;2m-----\x1b[0m   \x1b[38;5;3;48;5;23m--\x1b[0m   \x1b[38;5;87m----------\x1b[0m\n\x1b[48;5;2m     \x1b[0m   \x1b[38;5;3;48;5;23m  \x1b[0m   \x1b[38;5;87m2030203.00\x1b[0m\n"
+        )
+    else:
+        assert (
+            result
+            == "\nCOL A   COL B   COL 3     \n-----   --   ----------\nHello   World   12344342  \nThis is a test   World   1234      \n-----   --   ----------\n             2030203.00\n"
+        )
 
 
 def test_colors_whole_table_with_single_alignment(
@@ -209,10 +255,16 @@ def test_colors_whole_table_with_single_alignment(
         bg_colors=bg_colors,
         aligns="r",
     )
-    assert (
-        result
-        == "\n\x1b[48;5;2m         COL A\x1b[0m   \x1b[38;5;3;48;5;23mCOL B\x1b[0m   \x1b[38;5;87m     COL 3\x1b[0m\n\x1b[48;5;2m--------------\x1b[0m   \x1b[38;5;3;48;5;23m-----\x1b[0m   \x1b[38;5;87m----------\x1b[0m\n\x1b[48;5;2m         Hello\x1b[0m   \x1b[38;5;3;48;5;23mWorld\x1b[0m   \x1b[38;5;87m  12344342\x1b[0m\n\x1b[48;5;2mThis is a test\x1b[0m   \x1b[38;5;3;48;5;23mWorld\x1b[0m   \x1b[38;5;87m      1234\x1b[0m\n\x1b[48;5;2m--------------\x1b[0m   \x1b[38;5;3;48;5;23m-----\x1b[0m   \x1b[38;5;87m----------\x1b[0m\n\x1b[48;5;2m              \x1b[0m   \x1b[38;5;3;48;5;23m     \x1b[0m   \x1b[38;5;87m2030203.00\x1b[0m\n"
-    )
+    if SUPPORTS_ANSI:
+        assert (
+            result
+            == "\n\x1b[48;5;2m         COL A\x1b[0m   \x1b[38;5;3;48;5;23mCOL B\x1b[0m   \x1b[38;5;87m     COL 3\x1b[0m\n\x1b[48;5;2m--------------\x1b[0m   \x1b[38;5;3;48;5;23m-----\x1b[0m   \x1b[38;5;87m----------\x1b[0m\n\x1b[48;5;2m         Hello\x1b[0m   \x1b[38;5;3;48;5;23mWorld\x1b[0m   \x1b[38;5;87m  12344342\x1b[0m\n\x1b[48;5;2mThis is a test\x1b[0m   \x1b[38;5;3;48;5;23mWorld\x1b[0m   \x1b[38;5;87m      1234\x1b[0m\n\x1b[48;5;2m--------------\x1b[0m   \x1b[38;5;3;48;5;23m-----\x1b[0m   \x1b[38;5;87m----------\x1b[0m\n\x1b[48;5;2m              \x1b[0m   \x1b[38;5;3;48;5;23m     \x1b[0m   \x1b[38;5;87m2030203.00\x1b[0m\n"
+        )
+    else:
+        assert (
+            result
+            == "\n         COL A   COL B        COL 3\n--------------   -----   ----------\n         Hello   World     12344342\nThis is a test   World         1234\n--------------   -----   ----------\n                         2030203.00\n"
+        )
 
 
 def test_colors_whole_table_with_multiple_alignment(
@@ -227,10 +279,16 @@ def test_colors_whole_table_with_multiple_alignment(
         bg_colors=bg_colors,
         aligns=("c", "r", "l"),
     )
-    assert (
-        result
-        == "\n\x1b[48;5;2m    COL A     \x1b[0m   \x1b[38;5;3;48;5;23mCOL B\x1b[0m   \x1b[38;5;87mCOL 3     \x1b[0m\n\x1b[48;5;2m--------------\x1b[0m   \x1b[38;5;3;48;5;23m-----\x1b[0m   \x1b[38;5;87m----------\x1b[0m\n\x1b[48;5;2m    Hello     \x1b[0m   \x1b[38;5;3;48;5;23mWorld\x1b[0m   \x1b[38;5;87m12344342  \x1b[0m\n\x1b[48;5;2mThis is a test\x1b[0m   \x1b[38;5;3;48;5;23mWorld\x1b[0m   \x1b[38;5;87m1234      \x1b[0m\n\x1b[48;5;2m--------------\x1b[0m   \x1b[38;5;3;48;5;23m-----\x1b[0m   \x1b[38;5;87m----------\x1b[0m\n\x1b[48;5;2m              \x1b[0m   \x1b[38;5;3;48;5;23m     \x1b[0m   \x1b[38;5;87m2030203.00\x1b[0m\n"
-    )
+    if SUPPORTS_ANSI:
+        assert (
+            result
+            == "\n\x1b[48;5;2m    COL A     \x1b[0m   \x1b[38;5;3;48;5;23mCOL B\x1b[0m   \x1b[38;5;87mCOL 3     \x1b[0m\n\x1b[48;5;2m--------------\x1b[0m   \x1b[38;5;3;48;5;23m-----\x1b[0m   \x1b[38;5;87m----------\x1b[0m\n\x1b[48;5;2m    Hello     \x1b[0m   \x1b[38;5;3;48;5;23mWorld\x1b[0m   \x1b[38;5;87m12344342  \x1b[0m\n\x1b[48;5;2mThis is a test\x1b[0m   \x1b[38;5;3;48;5;23mWorld\x1b[0m   \x1b[38;5;87m1234      \x1b[0m\n\x1b[48;5;2m--------------\x1b[0m   \x1b[38;5;3;48;5;23m-----\x1b[0m   \x1b[38;5;87m----------\x1b[0m\n\x1b[48;5;2m              \x1b[0m   \x1b[38;5;3;48;5;23m     \x1b[0m   \x1b[38;5;87m2030203.00\x1b[0m\n"
+        )
+    else:
+        assert (
+            result
+            == "\n    COL A        COL B   COL 3     \n--------------   -----   ----------\n    Hello        World   12344342  \nThis is a test   World   1234      \n--------------   -----   ----------\n                         2030203.00\n"
+        )
 
 
 def test_colors_whole_table_with_multiline(data, header, footer, fg_colors, bg_colors):
@@ -240,10 +298,16 @@ def test_colors_whole_table_with_multiline(data, header, footer, fg_colors, bg_c
         bg_colors=bg_colors,
         multiline=True,
     )
-    assert (
-        result
-        == "\n\x1b[48;5;2mCharles\x1b[0m   \x1b[38;5;3;48;5;23mmy\x1b[0m   \x1b[38;5;87mbrother\x1b[0m\n\x1b[48;5;2mQuinton\x1b[0m   \x1b[38;5;3;48;5;23m  \x1b[0m   \x1b[38;5;87m       \x1b[0m\n\x1b[48;5;2mMurphy \x1b[0m   \x1b[38;5;3;48;5;23m  \x1b[0m   \x1b[38;5;87m       \x1b[0m\n\x1b[48;5;2m       \x1b[0m   \x1b[38;5;3;48;5;23m  \x1b[0m   \x1b[38;5;87m       \x1b[0m\n\x1b[48;5;2m1      \x1b[0m   \x1b[38;5;3;48;5;23m2 \x1b[0m   \x1b[38;5;87m3      \x1b[0m\n"
-    )
+    if SUPPORTS_ANSI:
+        assert (
+            result
+            == "\n\x1b[48;5;2mCharles\x1b[0m   \x1b[38;5;3;48;5;23mmy\x1b[0m   \x1b[38;5;87mbrother\x1b[0m\n\x1b[48;5;2mQuinton\x1b[0m   \x1b[38;5;3;48;5;23m  \x1b[0m   \x1b[38;5;87m       \x1b[0m\n\x1b[48;5;2mMurphy \x1b[0m   \x1b[38;5;3;48;5;23m  \x1b[0m   \x1b[38;5;87m       \x1b[0m\n\x1b[48;5;2m       \x1b[0m   \x1b[38;5;3;48;5;23m  \x1b[0m   \x1b[38;5;87m       \x1b[0m\n\x1b[48;5;2m1      \x1b[0m   \x1b[38;5;3;48;5;23m2 \x1b[0m   \x1b[38;5;87m3      \x1b[0m\n"
+        )
+    else:
+        assert (
+            result
+            == "\nCharles   my   brother\nQuinton               \nMurphy                \n                      \n1         2    3      \n"
+        )
 
 
 def test_colors_whole_table_log_friendly(data, header, footer, fg_colors, bg_colors):
@@ -314,7 +378,13 @@ def test_colors_whole_table_color_values(data, header, footer, fg_colors, bg_col
         bg_colors=bg_colors,
         color_values={"yellow": 11},
     )
-    assert (
-        result
-        == "\n\x1b[48;5;2mCOL A         \x1b[0m   \x1b[38;5;11;48;5;23mCOL B\x1b[0m   \x1b[38;5;87mCOL 3     \x1b[0m\n\x1b[48;5;2m--------------\x1b[0m   \x1b[38;5;11;48;5;23m-----\x1b[0m   \x1b[38;5;87m----------\x1b[0m\n\x1b[48;5;2mHello         \x1b[0m   \x1b[38;5;11;48;5;23mWorld\x1b[0m   \x1b[38;5;87m12344342  \x1b[0m\n\x1b[48;5;2mThis is a test\x1b[0m   \x1b[38;5;11;48;5;23mWorld\x1b[0m   \x1b[38;5;87m1234      \x1b[0m\n\x1b[48;5;2m--------------\x1b[0m   \x1b[38;5;11;48;5;23m-----\x1b[0m   \x1b[38;5;87m----------\x1b[0m\n\x1b[48;5;2m              \x1b[0m   \x1b[38;5;11;48;5;23m     \x1b[0m   \x1b[38;5;87m2030203.00\x1b[0m\n"
-    )
+    if SUPPORTS_ANSI:
+        assert (
+            result
+            == "\n\x1b[48;5;2mCOL A         \x1b[0m   \x1b[38;5;11;48;5;23mCOL B\x1b[0m   \x1b[38;5;87mCOL 3     \x1b[0m\n\x1b[48;5;2m--------------\x1b[0m   \x1b[38;5;11;48;5;23m-----\x1b[0m   \x1b[38;5;87m----------\x1b[0m\n\x1b[48;5;2mHello         \x1b[0m   \x1b[38;5;11;48;5;23mWorld\x1b[0m   \x1b[38;5;87m12344342  \x1b[0m\n\x1b[48;5;2mThis is a test\x1b[0m   \x1b[38;5;11;48;5;23mWorld\x1b[0m   \x1b[38;5;87m1234      \x1b[0m\n\x1b[48;5;2m--------------\x1b[0m   \x1b[38;5;11;48;5;23m-----\x1b[0m   \x1b[38;5;87m----------\x1b[0m\n\x1b[48;5;2m              \x1b[0m   \x1b[38;5;11;48;5;23m     \x1b[0m   \x1b[38;5;87m2030203.00\x1b[0m\n"
+        )
+    else:
+        assert (
+            result
+            == "\nCOL A            COL B   COL 3     \n--------------   -----   ----------\nHello            World   12344342  \nThis is a test   World   1234      \n--------------   -----   ----------\n                         2030203.00\n"
+        )

--- a/wasabi/tests/test_tables.py
+++ b/wasabi/tests/test_tables.py
@@ -1,6 +1,7 @@
 # coding: utf8
 from __future__ import unicode_literals, print_function
 
+import os
 import pytest
 from wasabi.tables import table, row
 
@@ -18,6 +19,21 @@ def header():
 @pytest.fixture()
 def footer():
     return ["", "", "2030203.00"]
+
+
+@pytest.fixture()
+def fg_colors():
+    return ["", "yellow", "87"]
+
+
+@pytest.fixture()
+def bg_colors():
+    return ["green", "23", ""]
+
+
+@pytest.fixture()
+def color_values():
+    return {"red": 76}
 
 
 def test_table_default(data):
@@ -82,4 +98,179 @@ def test_table_multiline(header):
     assert (
         result
         == "\nCOL A   COL B   COL 3  \n-----   -----   -------\nhello   foo     world  \n        bar            \n        baz            \n                       \nhello   world   world 1\n                world 2\n"
+    )
+
+
+def test_row_fg_colors(fg_colors):
+    result = row(("Hello", "World", "12344342"), fg_colors=fg_colors)
+    assert result == "Hello   \x1b[38;5;3mWorld\x1b[0m   \x1b[38;5;87m12344342\x1b[0m"
+
+
+def test_row_bg_colors(bg_colors):
+    result = row(("Hello", "World", "12344342"), bg_colors=bg_colors)
+    assert result == "\x1b[48;5;2mHello\x1b[0m   \x1b[48;5;23mWorld\x1b[0m   12344342"
+
+
+def test_row_fg_colors_and_bg_colors(fg_colors, bg_colors):
+    result = row(
+        ("Hello", "World", "12344342"), fg_colors=fg_colors, bg_colors=bg_colors
+    )
+    assert (
+        result
+        == "\x1b[48;5;2mHello\x1b[0m   \x1b[38;5;3;48;5;23mWorld\x1b[0m   \x1b[38;5;87m12344342\x1b[0m"
+    )
+
+
+def test_colors_whole_table_with_automatic_widths(data, header, footer, fg_colors, bg_colors):
+    result = table(
+        data,
+        header=header,
+        footer=footer,
+        divider=True,
+        fg_colors=fg_colors,
+        bg_colors=bg_colors,
+    )
+    assert (
+        result
+        == "\n\x1b[48;5;2mCOL A         \x1b[0m   \x1b[38;5;3mCOL B\x1b[0m   COL 3     \n\x1b[48;5;2m--------------\x1b[0m   \x1b[38;5;3m-----\x1b[0m   ----------\n\x1b[48;5;2mHello         \x1b[0m   \x1b[38;5;3mWorld\x1b[0m   12344342  \n\x1b[48;5;2mThis is a test\x1b[0m   \x1b[38;5;3mWorld\x1b[0m   1234      \n\x1b[48;5;2m--------------\x1b[0m   \x1b[38;5;3m-----\x1b[0m   ----------\n\x1b[48;5;2m              \x1b[0m   \x1b[38;5;3m     \x1b[0m   2030203.00\n"
+    )
+
+
+def test_colors_whole_table_with_supplied_spacing(data, header, footer, fg_colors, bg_colors):
+    result = table(
+        data,
+        header=header,
+        footer=footer,
+        divider=True,
+        fg_colors=fg_colors,
+        bg_colors=bg_colors,
+        spacing=5   
+    )
+    assert (
+        result
+        == "\n\x1b[48;5;2mCOL A         \x1b[0m     \x1b[38;5;3mCOL B\x1b[0m     COL 3     \n\x1b[48;5;2m--------------\x1b[0m     \x1b[38;5;3m-----\x1b[0m     ----------\n\x1b[48;5;2mHello         \x1b[0m     \x1b[38;5;3mWorld\x1b[0m     12344342  \n\x1b[48;5;2mThis is a test\x1b[0m     \x1b[38;5;3mWorld\x1b[0m     1234      \n\x1b[48;5;2m--------------\x1b[0m     \x1b[38;5;3m-----\x1b[0m     ----------\n\x1b[48;5;2m              \x1b[0m     \x1b[38;5;3m     \x1b[0m     2030203.00\n"
+    )
+
+def test_colors_whole_table_with_supplied_widths(data, header, footer, fg_colors, bg_colors):
+    result = table(
+        data,
+        header=header,
+        footer=footer,
+        divider=True,
+        fg_colors=fg_colors,
+        bg_colors=bg_colors,
+        widths=(5,2,10)
+    )
+    assert (
+        result
+        == "\n\x1b[48;5;2mCOL A\x1b[0m   \x1b[38;5;3mCOL B\x1b[0m   COL 3     \n\x1b[48;5;2m-----\x1b[0m   \x1b[38;5;3m--\x1b[0m   ----------\n\x1b[48;5;2mHello\x1b[0m   \x1b[38;5;3mWorld\x1b[0m   12344342  \n\x1b[48;5;2mThis is a test\x1b[0m   \x1b[38;5;3mWorld\x1b[0m   1234      \n\x1b[48;5;2m-----\x1b[0m   \x1b[38;5;3m--\x1b[0m   ----------\n\x1b[48;5;2m     \x1b[0m   \x1b[38;5;3m  \x1b[0m   2030203.00\n"
+    )
+
+def test_colors_whole_table_with_single_alignment(data, header, footer, fg_colors, bg_colors):
+    result = table(
+        data,
+        header=header,
+        footer=footer,
+        divider=True,
+        fg_colors=fg_colors,
+        bg_colors=bg_colors,
+        aligns='r'
+    )
+    assert (
+        result
+        == "\n\x1b[48;5;2m         COL A\x1b[0m   \x1b[38;5;3mCOL B\x1b[0m        COL 3\n\x1b[48;5;2m--------------\x1b[0m   \x1b[38;5;3m-----\x1b[0m   ----------\n\x1b[48;5;2m         Hello\x1b[0m   \x1b[38;5;3mWorld\x1b[0m     12344342\n\x1b[48;5;2mThis is a test\x1b[0m   \x1b[38;5;3mWorld\x1b[0m         1234\n\x1b[48;5;2m--------------\x1b[0m   \x1b[38;5;3m-----\x1b[0m   ----------\n\x1b[48;5;2m              \x1b[0m   \x1b[38;5;3m     \x1b[0m   2030203.00\n"
+    )
+
+def test_colors_whole_table_with_multiple_alignment(data, header, footer, fg_colors, bg_colors):
+    result = table(
+        data,
+        header=header,
+        footer=footer,
+        divider=True,
+        fg_colors=fg_colors,
+        bg_colors=bg_colors,
+        aligns=('c', 'r', 'l')
+    )
+    assert (
+        result
+        == "\n\x1b[48;5;2m    COL A     \x1b[0m   \x1b[38;5;3mCOL B\x1b[0m   COL 3     \n\x1b[48;5;2m--------------\x1b[0m   \x1b[38;5;3m-----\x1b[0m   ----------\n\x1b[48;5;2m    Hello     \x1b[0m   \x1b[38;5;3mWorld\x1b[0m   12344342  \n\x1b[48;5;2mThis is a test\x1b[0m   \x1b[38;5;3mWorld\x1b[0m   1234      \n\x1b[48;5;2m--------------\x1b[0m   \x1b[38;5;3m-----\x1b[0m   ----------\n\x1b[48;5;2m              \x1b[0m   \x1b[38;5;3m     \x1b[0m   2030203.00\n"
+    )
+
+def test_colors_whole_table_with_multiline(data, header, footer, fg_colors, bg_colors):
+    result = table(
+        data = ((['Charles', 'Quinton', 'Murphy'], 'my', 'brother'), ('1', '2', '3')),
+        fg_colors=fg_colors,
+        bg_colors=bg_colors,
+        multiline=True
+    )
+    assert (
+        result
+        == "\n\x1b[48;5;2mCharles\x1b[0m   \x1b[38;5;3mmy\x1b[0m   brother\n\x1b[48;5;2mQuinton\x1b[0m   \x1b[38;5;3m  \x1b[0m          \n\x1b[48;5;2mMurphy \x1b[0m   \x1b[38;5;3m  \x1b[0m          \n\x1b[48;5;2m       \x1b[0m   \x1b[38;5;3m  \x1b[0m          \n\x1b[48;5;2m1      \x1b[0m   \x1b[38;5;3m2 \x1b[0m   3      \n"
+    )
+
+def test_colors_whole_table_log_friendly(data, header, footer, fg_colors, bg_colors):
+    ENV_LOG_FRIENDLY = "WASABI_LOG_FRIENDLY"
+    os.environ[ENV_LOG_FRIENDLY] = "True"
+    result = table(
+        data,
+        header=header,
+        footer=footer,
+        divider=True,
+        fg_colors=fg_colors,
+        bg_colors=bg_colors,
+    )
+    assert (
+        result
+        == "\nCOL A            COL B   COL 3     \n--------------   -----   ----------\nHello            World   12344342  \nThis is a test   World   1234      \n--------------   -----   ----------\n                         2030203.00\n"
+    )
+    del os.environ[ENV_LOG_FRIENDLY]
+
+
+def test_colors_whole_table_log_friendly_prefix(data, header, footer, fg_colors, bg_colors):
+    ENV_LOG_FRIENDLY = "CUSTOM_LOG_FRIENDLY"
+    os.environ[ENV_LOG_FRIENDLY] = "True"
+    result = table(
+        data,
+        header=header,
+        footer=footer,
+        divider=True,
+        fg_colors=fg_colors,
+        bg_colors=bg_colors,
+        env_prefix='CUSTOM'
+    )
+    assert (
+        result
+        == "\nCOL A            COL B   COL 3     \n--------------   -----   ----------\nHello            World   12344342  \nThis is a test   World   1234      \n--------------   -----   ----------\n                         2030203.00\n"
+    )
+    del os.environ[ENV_LOG_FRIENDLY]
+
+def test_colors_whole_table_supports_ansi_false(data, header, footer, fg_colors, bg_colors):
+    os.environ['ANSI_COLORS_DISABLED'] = "True"
+    result = table(
+        data,
+        header=header,
+        footer=footer,
+        divider=True,
+        fg_colors=fg_colors,
+        bg_colors=bg_colors,
+    )
+    assert (
+        result
+        == "\nCOL A            COL B   COL 3     \n--------------   -----   ----------\nHello            World   12344342  \nThis is a test   World   1234      \n--------------   -----   ----------\n                         2030203.00\n"
+    )
+    del os.environ['ANSI_COLORS_DISABLED']
+
+def test_colors_whole_table_color_values(data, header, footer, fg_colors, bg_colors):
+    result = table(
+        data,
+        header=header,
+        footer=footer,
+        divider=True,
+        fg_colors=fg_colors,
+        bg_colors=bg_colors,
+        color_values= {'yellow': 11}
+    )
+    assert (
+        result
+        == "\n\x1b[48;5;2mCOL A         \x1b[0m   \x1b[38;5;11mCOL B\x1b[0m   COL 3     \n\x1b[48;5;2m--------------\x1b[0m   \x1b[38;5;11m-----\x1b[0m   ----------\n\x1b[48;5;2mHello         \x1b[0m   \x1b[38;5;11mWorld\x1b[0m   12344342  \n\x1b[48;5;2mThis is a test\x1b[0m   \x1b[38;5;11mWorld\x1b[0m   1234      \n\x1b[48;5;2m--------------\x1b[0m   \x1b[38;5;11m-----\x1b[0m   ----------\n\x1b[48;5;2m              \x1b[0m   \x1b[38;5;11m     \x1b[0m   2030203.00\n"
     )

--- a/wasabi/tests/test_tables.py
+++ b/wasabi/tests/test_tables.py
@@ -132,6 +132,38 @@ def test_row_fg_colors_and_bg_colors(fg_colors, bg_colors):
         assert result == "Hello   World   12344342"
 
 
+def test_row_fg_colors_and_bg_colors_log_friendly(fg_colors, bg_colors):
+    ENV_LOG_FRIENDLY = "WASABI_LOG_FRIENDLY"
+    os.environ[ENV_LOG_FRIENDLY] = "True"
+    result = row(
+        ("Hello", "World", "12344342"), fg_colors=fg_colors, bg_colors=bg_colors
+    )
+    assert result == "Hello   World   12344342"
+    del os.environ[ENV_LOG_FRIENDLY]
+
+
+def test_row_fg_colors_and_bg_colors_log_friendly_prefix(fg_colors, bg_colors):
+    ENV_LOG_FRIENDLY = "CUSTOM_LOG_FRIENDLY"
+    os.environ[ENV_LOG_FRIENDLY] = "True"
+    result = row(
+        ("Hello", "World", "12344342"),
+        fg_colors=fg_colors,
+        bg_colors=bg_colors,
+        env_prefix="CUSTOM",
+    )
+    assert result == "Hello   World   12344342"
+    del os.environ[ENV_LOG_FRIENDLY]
+
+
+def test_row_fg_colors_and_bg_colors_supports_ansi_false(fg_colors, bg_colors):
+    os.environ["ANSI_COLORS_DISABLED"] = "True"
+    result = row(
+        ("Hello", "World", "12344342"), fg_colors=fg_colors, bg_colors=bg_colors
+    )
+    assert result == "Hello   World   12344342"
+    del os.environ["ANSI_COLORS_DISABLED"]
+
+
 def test_colors_whole_table_with_automatic_widths(
     data, header, footer, fg_colors, bg_colors
 ):


### PR DESCRIPTION
- Allow foreground and background colors to be specified for individual table columns
- Allow color values as well as color names as the `color` parameter to `Printer.text()`
- Add a new `bg_color`parameter to `Printer.text()`
- Correct a couple of minor documentation errors 