### PR TITLE
Add symbols to diff_strings

### DIFF
--- a/wasabi/tests/test_util.py
+++ b/wasabi/tests/test_util.py
@@ -66,3 +66,10 @@ def test_diff_strings():
     b = "yo\nwide\nworld\nweb"
     expected = "\x1b[38;5;16;48;5;2myo\x1b[0m\n\x1b[38;5;16;48;5;2mwide\x1b[0m\n\x1b[38;5;16;48;5;1mhello\x1b[0m\nworld\n\x1b[38;5;16;48;5;1mwide\x1b[0m\nweb"
     assert diff_strings(a, b) == expected
+
+
+def test_diff_strings_with_symbols():
+    a = "hello\nworld\nwide\nweb"
+    b = "yo\nwide\nworld\nweb"
+    expected = "\x1b[38;5;16;48;5;2m+ yo\x1b[0m\n\x1b[38;5;16;48;5;2m+ wide\x1b[0m\n\x1b[38;5;16;48;5;1m- hello\x1b[0m\nworld\n\x1b[38;5;16;48;5;1m- wide\x1b[0m\nweb"
+    assert diff_strings(a, b, add_symbols=True) == expected

--- a/wasabi/util.py
+++ b/wasabi/util.py
@@ -48,6 +48,9 @@ ICONS = {
     MESSAGES.INFO: "\u2139" if not NO_UTF8 else "[i]",
 }
 
+INSERT_SYMBOL = "+"
+DELETE_SYMBOL = "-"
+
 
 # Python 2 compatibility
 IS_PYTHON_2 = sys.version_info[0] == 2
@@ -126,7 +129,7 @@ def format_repr(obj, max_len=50, ellipsis="..."):
         return string
 
 
-def diff_strings(a, b, fg="black", bg=("green", "red")):
+def diff_strings(a, b, fg="black", bg=("green", "red"), add_symbols=False):
     """Compare two strings and return a colored diff with red/green background
     for deletion and insertions.
 
@@ -135,6 +138,8 @@ def diff_strings(a, b, fg="black", bg=("green", "red")):
     fg (unicode / int): Foreground color. String name or 0 - 256 (see COLORS).
     bg (tuple): Background colors as (insert, delete) tuple of string name or
         0 - 256 (see COLORS).
+    add_symbols (bool): Whether to add symbols before the diff lines. Uses '+'
+        for inserts and '-' for deletions. Default is False.
     RETURNS (unicode): The formatted diff.
     """
     a = a.split("\n")
@@ -147,9 +152,11 @@ def diff_strings(a, b, fg="black", bg=("green", "red")):
                 output.append(item)
         if opcode == "insert" or opcode == "replace":
             for item in b[b0:b1]:
+                item = f"{INSERT_SYMBOL} {item}" if add_symbols else item
                 output.append(color(item, fg=fg, bg=bg[0]))
         if opcode == "delete" or opcode == "replace":
             for item in a[a0:a1]:
+                item = f"{DELETE_SYMBOL} {item}" if add_symbols else item
                 output.append(color(item, fg=fg, bg=bg[1]))
     return "\n".join(output)
 

--- a/wasabi/util.py
+++ b/wasabi/util.py
@@ -152,11 +152,11 @@ def diff_strings(a, b, fg="black", bg=("green", "red"), add_symbols=False):
                 output.append(item)
         if opcode == "insert" or opcode == "replace":
             for item in b[b0:b1]:
-                item = f"{INSERT_SYMBOL} {item}" if add_symbols else item
+                item = "{} {}".format(INSERT_SYMBOL, item) if add_symbols else item
                 output.append(color(item, fg=fg, bg=bg[0]))
         if opcode == "delete" or opcode == "replace":
             for item in a[a0:a1]:
-                item = f"{DELETE_SYMBOL} {item}" if add_symbols else item
+                item = "{} {}".format(DELETE_SYMBOL, item) if add_symbols else item
                 output.append(color(item, fg=fg, bg=bg[1]))
     return "\n".join(output)
 


### PR DESCRIPTION
In this commit, I added a special parameter to diff_strings called `add_symbols`. This adds a '+' or '-' symbol depending on the diff'd line (where '+' for inserts and '-' for deletions).

The CI fails because of some non-supported Python runners. I made a fix on this PR: https://github.com/ines/wasabi/pull/21.