### PR TITLE
Remove deprecated components of the CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,7 +25,7 @@ jobs:
         imageName: 'vs2017-win2016'
         python.version: '2.7'
       Python27Mac:
-        imageName: 'macos-10.14'
+        imageName: 'macOS-10.15'
         python.version: '2.7'
       Python36Linux:
         imageName: 'ubuntu-20.04'
@@ -34,7 +34,7 @@ jobs:
         imageName: 'vs2017-win2016'
         python.version: '3.6'
       Python36Mac:
-        imageName: 'macos-10.14'
+        imageName: 'macOS-10.15'
         python.version: '3.6'
       Python37Linux:
         imageName: 'ubuntu-20.04'
@@ -43,7 +43,7 @@ jobs:
         imageName: 'vs2017-win2016'
         python.version: '3.7'
       Python37Mac:
-        imageName: 'macos-10.14'
+        imageName: 'macOS-10.15'
         python.version: '3.7'
       Python38Linux:
         imageName: 'ubuntu-20.04'
@@ -52,7 +52,7 @@ jobs:
         imageName: 'vs2017-win2016'
         python.version: '3.8'
       Python38Mac:
-        imageName: 'macos-10.14'
+        imageName: 'macOS-10.15'
         python.version: '3.8'
       Python39Linux:
         imageName: 'ubuntu-20.04'
@@ -61,7 +61,7 @@ jobs:
         imageName: 'vs2017-win2016'
         python.version: '3.9'
       Python39Mac:
-        imageName: 'macos-10.14'
+        imageName: 'macOS-10.15'
         python.version: '3.9'
       Python310Linux:
         imageName: 'ubuntu-20.04'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,15 +27,6 @@ jobs:
       Python27Mac:
         imageName: 'macos-10.14'
         python.version: '2.7'
-      Python35Linux:
-        imageName: 'ubuntu-20.04'
-        python.version: '3.5'
-      Python35Windows:
-        imageName: 'vs2017-win2016'
-        python.version: '3.5'
-      Python35Mac:
-        imageName: 'macos-10.14'
-        python.version: '3.5'
       Python36Linux:
         imageName: 'ubuntu-20.04'
         python.version: '3.6'


### PR DESCRIPTION
There were two major changes in the CI:

1. Python3.5 is [not supported by Azure Pipelines anymore since January 24](https://github.com/microsoft/azure-pipelines-tasks/issues/15608), I removed them.
2. `macOS-10.14` [has been deprecated by Azure Pipelines last December 10, 2021]( https://devblogs.microsoft.com/devops/hosted-pipelines-image-deprecation/). I bumped their versions to `macOS-10.15`