### PR TITLE
Add explicit exports for Wasabi

### DIFF
--- a/wasabi/__init__.py
+++ b/wasabi/__init__.py
@@ -6,3 +6,20 @@ from .util import MESSAGES  # noqa
 from .util import color, diff_strings, format_repr, get_raw_input, wrap  # noqa
 
 msg = Printer()
+
+# fmt: off
+__all__ = [
+    "color",
+    "diff_strings",
+    "format_repr",
+    "get_raw_input",
+    "msg",
+    "row",
+    "table",
+    "wrap",
+    "MarkdownRenderer",
+    "MESSAGES",
+    "Printer",
+    "TracebackPrinter",
+]
+# fmt: on


### PR DESCRIPTION
Adding explicit exports to avoid `mypy` errors in upstream packages like 
```
thinc/util.py:35: error: Module "wasabi" does not explicitly export attribute "table"  [attr-defined]
```